### PR TITLE
Calling [self init]

### DIFF
--- a/Pod/Classes/UIAlertView+NSErrorAddition.m
+++ b/Pod/Classes/UIAlertView+NSErrorAddition.m
@@ -8,7 +8,7 @@
 
 @implementation UIAlertView (NSErrorAddition)
 - (instancetype)initWithError:(NSError *) error {
-    self = [super init];
+    self = [self init];
     if (self) {
         self.title = [error localizedDescription];
         NSMutableArray *messageArray = [NSMutableArray array];


### PR DESCRIPTION
Calling `self` because this is a category not a sub class.
